### PR TITLE
Small cleanup, envy.home support and throwaway envs

### DIFF
--- a/cmd/envyd.go
+++ b/cmd/envyd.go
@@ -29,7 +29,9 @@ func main() {
 		pathUser := parts[2]
 		var pathEnv, sshUser string
 		if len(parts) > 3 && parts[3] != "hterm" {
-			pathEnv = parts[3]
+			if parts[3] != "-" {
+				pathEnv = parts[3]
+			}
 			sshUser = pathUser + "+" + pathEnv
 		} else {
 			sshUser = pathUser

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -1,7 +1,23 @@
 #!/bin/bash
 
-IFS="+" read USER ENV <<< "${USER:?}"
-ENV="${ENV:-$USER}"
+# A temporary varible to help checkin whether the environment has been explicitly
+# set to blank
+ENVIRONMENT_SET='0'
+if [[ "${USER:?}" =~ '+' ]]; then
+  ENVIRONMENT_SET='1'
+fi
+
+IFS="+" read USER ENV <<< "${USER}"
+
+THROWAWAY='0'
+if [ "$ENVIRONMENT_SET" = '1' ] && [ -z "$ENV" ]; then
+  THROWAWAY='1'
+else
+  ENV=$USER
+fi
+
+# There's no need for this to be around anymore from this point on
+unset ENVIRONMENT_SET
 
 # The path relative to the host Docker machine where data will be persisted, used
 # for adjusting paths when nesting containers
@@ -105,6 +121,9 @@ env-session() {
     status=$?
   done
   docker rm -f "$session" > /dev/null
+  if [ "$THROWAWAY" = '1' ]; then
+    docker rmi "$ENV_IMAGE" > /dev/null
+  fi
   [[ "$status" == "128" ]] || exit "$status"
 }
 

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -12,6 +12,7 @@ USER_ROOT="${USER_ROOT:-/data/users/$USER}"
 
 # The obvious ones
 ENV_IMAGE="$USER/$ENV"
+ENV_ROOT="$USER_ROOT/envs/$ENV"
 DIND_CONTAINER_NAME="$USER.$ENV"
 
 data-init() {
@@ -29,11 +30,11 @@ user-init() {
 }
 
 env-init() {
-  if [[ ! -d "$USER_ROOT/envs/$ENV" ]]; then
-    cp -R /tmp/data/env "$USER_ROOT/envs/$ENV"
+  if [[ ! -d "$ENV_ROOT" ]]; then
+    cp -R /tmp/data/env "$ENV_ROOT"
   fi
   env-docker
-  cd "$USER_ROOT/envs/$ENV"
+  cd "$ENV_ROOT"
   if ! docker history $ENV_IMAGE &> /dev/null; then
     echo "Building environment ... "
     docker build -t $ENV_IMAGE . &> /dev/null
@@ -41,7 +42,7 @@ env-init() {
 }
 
 env-docker() {
-  mkdir -p "$USER_ROOT/envs/$ENV/run"
+  mkdir -p "$ENV_ROOT/run"
   if ! docker diff $DIND_CONTAINER_NAME &> /dev/null; then
     docker run -d --privileged \
       --name $DIND_CONTAINER_NAME \

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -8,7 +8,11 @@ ENV="${ENV:-$USER}"
 HOST_DATA="${HOST_DATA:?}"
 
 # This is where users environments will be stored
-USER_ROOT="${USER_ROOT:-/data/users/$USER}"
+USER_ROOT="${USER_ROOT:-"/data/users/$USER"}"
+
+# Not really needed to be defined as a variable but allows for injecting its value
+# from outside (might be useful for testing purposes)
+GH_ENVY_HOME=${GH_ENVY_HOME:-"https://github.com/$USER/envy.home.git"}
 
 # The obvious ones
 ENV_IMAGE="$USER/$ENV"
@@ -24,8 +28,8 @@ user-init() {
   if [[ ! -d "$USER_ROOT" ]]; then
     mkdir -p "$USER_ROOT"
     mkdir -p "$USER_ROOT/envs"
-    if $(wget --spider https://github.com/$USER/envy.home &>/dev/null); then
-      git clone https://github.com/$USER/envy.home.git "$USER_ROOT/home"
+    if $(wget --spider $GH_ENVY_HOME &>/dev/null); then
+      git clone $GH_ENVY_HOME "$USER_ROOT/home"
     else
       mkdir -p "$USER_ROOT/home"
     fi

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -10,8 +10,10 @@ HOST_DATA="${HOST_DATA:?}"
 # This is where users environments will be stored
 USER_ROOT="${USER_ROOT:-/data/users/$USER}"
 
+ENV_IMAGE="$USER/$ENV"
+
 data-init() {
-  mkdir -p /data/users
+  mkdir -p $(readlink -f "${USER_ROOT}/..")
   cp /bin/envcmd /data/.envcmd
 }
 
@@ -30,9 +32,9 @@ env-init() {
   fi
   env-docker
   cd "$USER_ROOT/envs/$ENV"
-  if ! docker history "$USER/$ENV" &> /dev/null; then
+  if ! docker history $ENV_IMAGE &> /dev/null; then
     echo "Building environment ... "
-    docker build -t "$USER/$ENV" . &> /dev/null
+    docker build -t $ENV_IMAGE . &> /dev/null
   fi
 }
 
@@ -58,7 +60,7 @@ env-session() {
       read cmd args <<< "$(cat $USER_ROOT/root/$session)"
       case "$cmd" in
       *rebuild)
-        docker build -t "$USER/$ENV" .
+        docker build -t "$ENV_IMAGE" .
         ;;
       *switch)
         echo "Switching to $args ... "
@@ -67,7 +69,7 @@ env-session() {
         ;;
       *commit)
         echo "Committing to $args ... "
-        docker commit "$session" "$USER/$ENV" > /dev/null
+        docker commit "$session" "$ENV_IMAGE" > /dev/null
         ;;
       esac
       rm -f "$USER_ROOT/root/$session"
@@ -88,7 +90,7 @@ env-session() {
       --volume "$HOST_DATA/users/$USER/root:/root" \
       --volume "$HOST_DATA/users/$USER/home:/home/$USER" \
       --volume "$HOST_DATA:/admin" \
-      "$USER/$ENV" $(docker-cmd)
+      "$ENV_IMAGE" $(docker-cmd)
     status=$?
   done
   docker rm -f "$session" > /dev/null
@@ -96,10 +98,10 @@ env-session() {
 }
 
 docker-cmd() {
-  if [[ "$(docker inspect -f {{.Config.Cmd}} $USER/$ENV)" != "<no value>" ]]; then
+  if [[ "$(docker inspect -f {{.Config.Cmd}} $ENV_IMAGE)" != "<no value>" ]]; then
     return
   fi
-  if [[ "$(docker inspect -f {{.Config.Entrypoint}} $USER/$ENV)" != "<no value>" ]]; then
+  if [[ "$(docker inspect -f {{.Config.Entrypoint}} $ENV_IMAGE)" != "<no value>" ]]; then
     return
   fi
   echo "/bin/sh"

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -4,26 +4,29 @@ IFS="+" read USER ENV <<< "${USER:?}"
 ENV="${ENV:-$USER}"
 HOST_DATA="${HOST_DATA:?}"
 
+# This is where users environments will be stored
+USER_ROOT="${USER_ROOT:-/data/users/$USER}"
+
 data-init() {
   mkdir -p /data/users
   cp /bin/envcmd /data/.envcmd
 }
 
 user-init() {
-  if [[ ! -d "/data/users/$USER" ]]; then
-    mkdir -p "/data/users/$USER"
-    mkdir -p "/data/users/$USER/envs"
-    mkdir -p "/data/users/$USER/home"
-    cp -R /tmp/data/root "/data/users/$USER/root"
+  if [[ ! -d "$USER_ROOT" ]]; then
+    mkdir -p "$USER_ROOT"
+    mkdir -p "$USER_ROOT/envs"
+    mkdir -p "$USER_ROOT/home"
+    cp -R /tmp/data/root "$USER_ROOT/root"
   fi
 }
 
 env-init() {
-  if [[ ! -d "/data/users/$USER/envs/$ENV" ]]; then
-    cp -R /tmp/data/env "/data/users/$USER/envs/$ENV"
+  if [[ ! -d "$USER_ROOT/envs/$ENV" ]]; then
+    cp -R /tmp/data/env "$USER_ROOT/envs/$ENV"
   fi
   env-docker
-  cd "/data/users/$USER/envs/$ENV"
+  cd "$USER_ROOT/envs/$ENV"
   if ! docker history "$USER/$ENV" &> /dev/null; then
     echo "Building environment ... "
     docker build -t "$USER/$ENV" . &> /dev/null
@@ -31,7 +34,7 @@ env-init() {
 }
 
 env-docker() {
-  mkdir -p "/data/users/$USER/envs/$ENV/run"
+  mkdir -p "$USER_ROOT/envs/$ENV/run"
   if ! docker diff "$USER.$ENV" &> /dev/null; then
     docker run -d --privileged \
       --name "$USER.$ENV" \
@@ -48,8 +51,8 @@ env-session() {
   local status="128"
   set +e
   while [[ "$status" == "128" ]]; do
-    if [[ -f "/data/users/$USER/root/$session" ]]; then
-      read cmd args <<< "$(cat /data/users/$USER/root/$session)"
+    if [[ -f "$USER_ROOT/root/$session" ]]; then
+      read cmd args <<< "$(cat $USER_ROOT/root/$session)"
       case "$cmd" in
       *rebuild)
         docker build -t "$USER/$ENV" .
@@ -64,7 +67,7 @@ env-session() {
         docker commit "$session" "$USER/$ENV" > /dev/null
         ;;
       esac
-      rm -f "/data/users/$USER/root/$session"
+      rm -f "$USER_ROOT/root/$session"
     fi
     docker rm -f "$session" &> /dev/null
     docker run -it \

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -10,7 +10,9 @@ HOST_DATA="${HOST_DATA:?}"
 # This is where users environments will be stored
 USER_ROOT="${USER_ROOT:-/data/users/$USER}"
 
+# The obvious ones
 ENV_IMAGE="$USER/$ENV"
+DIND_CONTAINER_NAME="$USER.$ENV"
 
 data-init() {
   mkdir -p $(readlink -f "${USER_ROOT}/..")
@@ -40,9 +42,9 @@ env-init() {
 
 env-docker() {
   mkdir -p "$USER_ROOT/envs/$ENV/run"
-  if ! docker diff "$USER.$ENV" &> /dev/null; then
+  if ! docker diff $DIND_CONTAINER_NAME &> /dev/null; then
     docker run -d --privileged \
-      --name "$USER.$ENV" \
+      --name $DIND_CONTAINER_NAME \
       --hostname "$ENV" \
       --env PORT=2375 \
       --restart always \
@@ -77,7 +79,7 @@ env-session() {
     docker rm -f "$session" &> /dev/null
     docker run -it \
       --name "$session" \
-      --net "container:$USER.$ENV" \
+      --net "container:$DIND_CONTAINER_NAME" \
       --env "HOSTNAME=$ENV" \
       --env "ENVY_SESSION=$session" \
       --env "ENVY_RANDOM=$RANDOM" \

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -2,6 +2,9 @@
 
 IFS="+" read USER ENV <<< "${USER:?}"
 ENV="${ENV:-$USER}"
+
+# The path relative to the host Docker machine where data will be persisted, used
+# for adjusting paths when nesting containers
 HOST_DATA="${HOST_DATA:?}"
 
 # This is where users environments will be stored

--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -24,7 +24,11 @@ user-init() {
   if [[ ! -d "$USER_ROOT" ]]; then
     mkdir -p "$USER_ROOT"
     mkdir -p "$USER_ROOT/envs"
-    mkdir -p "$USER_ROOT/home"
+    if $(wget --spider https://github.com/$USER/envy.home &>/dev/null); then
+      git clone https://github.com/$USER/envy.home.git "$USER_ROOT/home"
+    else
+      mkdir -p "$USER_ROOT/home"
+    fi
     cp -R /tmp/data/root "$USER_ROOT/root"
   fi
 }


### PR DESCRIPTION
This provides just a little bit cleanup that I think will make other people lives easier and it should be able to close GH-16 and GH-14.

The part where it checks for the throwaway environment is a bit messed up but it is the best I could do with my current bash knowledge. I'm happy to refactor it if anyone knows a better way of doing that :blush: 

_Sorry for doing too much in a single PR, I'm cool to extract them into smaller ones :grin:_
