### PR TITLE
Send SIGHUP to enterenv process and remove container when websockets are closed

### DIFF
--- a/scripts/enterenv
+++ b/scripts/enterenv
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+clean-up() {
+  if [[ -n "${LAST_SESSION}" ]]; then
+    docker stop $LAST_SESSION
+    docker rm $LAST_SESSION
+  fi
+}
+trap clean-up SIGHUP
+
 root-init() {
   mkdir -p /envy/users
   cp /bin/envcmd /envy/.envcmd
@@ -48,6 +56,7 @@ env-session() {
   while [[ "$status" == "128" ]]; do
     session-reload-env "$session"
     docker rm -f "$session" &> /dev/null
+    export LAST_SESSION=$session
     docker run -it \
       --name "$session" \
       --net "container:$USER.$ENVIRON" \


### PR DESCRIPTION
A potential fix for GH-30.

I tried many other things to achieve the same result and it would either not kill the process or leave zombie `enterenv` processes behind. 
